### PR TITLE
Fix topic name

### DIFF
--- a/phoxi_img_converter/launch/converted_image.launch
+++ b/phoxi_img_converter/launch/converted_image.launch
@@ -2,6 +2,6 @@
 <launch>
   <node pkg="phoxi_img_converter" type="phoxi_img_converter_node" name="phoxi_img_converter_node" output="screen">
     <remap from="/image0" to="/photoneo_center/texture" />
-    <remap from="/converted_image" to="/photoneo_center/rgb_texture" />
+    <remap from="/converted_image" to="/photoneo_center/converted_rgb_texture" />
    </node>
 </launch>


### PR DESCRIPTION
photoneo_center/rgb_texture トピックの名前が，phoxi_camera 側から出力されるものと，phoxi_img_converter 側から出力されるものでかぶっていたため起こっていた #23 の問題を修正しました．修正後は，phoxi_camera 側から出力されるトピック名はそのままですが，phoxi_img_converter 側から出力されるトピック名は，/photoneo_center/converted_rgb_texture となっています． @ShunjiroOsada ，動作確認をお願いします．